### PR TITLE
fix!: set right version of packages and use caret for memcache-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11281,7 +11281,7 @@
       "dev": true
     },
     "packages/memcache-client": {
-      "version": "1.10.1",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.defaults": "4.2.0",
@@ -11303,7 +11303,7 @@
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "packages/memcache-parser": {
-      "version": "1.2.8",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"

--- a/packages/memcache-client/package.json
+++ b/packages/memcache-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache-client",
-  "version": "1.10.1",
+  "version": "0.10.1",
   "description": "NodeJS memcached client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/memcache-parser/package.json
+++ b/packages/memcache-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache-parser",
-  "version": "1.2.8",
+  "version": "0.2.8",
   "description": "A very efficient NodeJS memcached ASCII Protocol parser by using only Buffer APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- fixed wrong versions for `memache-client` and `memcache-parser`
- changed back caret version for `memcache-parser` in `memcache-client`