### PR TITLE
Add a `noDelay` client option that allows enabling `TCP_NODELAY` to improve latency

### DIFF
--- a/packages/memcache-client/README.md
+++ b/packages/memcache-client/README.md
@@ -166,6 +166,7 @@ const options = {
   lifetime: 100, // TTL 100 seconds
   cmdTimeout: 3000, // command timeout in milliseconds
   connectTimeout: 8000, // connect to server timeout in ms
+  noDelay: true, // whether to enable TCP_NODELAY on connections
   compressor: require("custom-compressor"),
   logger: require("./custom-logger"),
   Promise,
@@ -185,6 +186,7 @@ const client = new MemcacheClient(options);
 
 -   `ignoreNotStored` - **_optional_** If set to true, then will not treat `NOT_STORED` reply from any store commands as error.  Use this for [Mcrouter AllAsyncRoute] mode.
 -   `lifetime` - **_optional_** Your cache TTL in **_seconds_** to use for all entries.  DEFAULT: 60 seconds.
+-   `noDelay` - **_optional_** Whether to enable `TCP_NODELAY` on connections to decrease latency. DEFAULT: false
 -   `cmdTimeout` - **_optional_** Command timeout in milliseconds.  DEFAULT: 5000 ms.
     -   If a command didn't receive response before this timeout value, then it will cause the connection to shutdown and returns Error.
 -   `connectTimeout` - **_optional_** Custom self connect to server timeout in milliseconds.  It's disabled if set to 0.  DEFAULT: 0

--- a/packages/memcache-client/src/lib/connection.ts
+++ b/packages/memcache-client/src/lib/connection.ts
@@ -342,6 +342,8 @@ export class MemcacheConnection extends MemcacheParser {
   }
 
   _setupConnection(socket: Socket): void {
+    socket.setNoDelay(true);
+
     socket.on("data", this.onData.bind(this));
 
     socket.on("end", () => {

--- a/packages/memcache-client/src/lib/connection.ts
+++ b/packages/memcache-client/src/lib/connection.ts
@@ -342,7 +342,9 @@ export class MemcacheConnection extends MemcacheParser {
   }
 
   _setupConnection(socket: Socket): void {
-    socket.setNoDelay(true);
+    if (this.client?.options?.noDelay) {
+      socket.setNoDelay(true);
+    }
 
     socket.on("data", this.onData.bind(this));
 

--- a/packages/memcache-client/src/types.ts
+++ b/packages/memcache-client/src/types.ts
@@ -43,6 +43,7 @@ export type MemcacheClientOptions = {
   server: ServerDefinition | SingleServerEntry | MultipleServerEntry | string;
   ignoreNotStored?: boolean;
   lifetime?: number;
+  noDelay?: boolean;
   cmdTimeout?: number;
   connectTimeout?: number;
   keepDangleSocket?: boolean;


### PR DESCRIPTION
This appears to significantly improve the performance of `set` commands (from ~47.8ms to ~2.8ms p50 in my use case).

Fixes #7

<img src="https://github.com/electrode-io/memcache/assets/1465/37ce2e24-dac7-4f28-a182-85a6c329157e" width="470">
